### PR TITLE
Fix payment modal display on upsell pages

### DIFF
--- a/funil_completo/up1.html
+++ b/funil_completo/up1.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/x-icon" href="../public/images/logo_icon_branco.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link rel="stylesheet" href="../public/css/payment-modal.css">
     <style>
         :root {
             --color-primary-start: #F58370;

--- a/funil_completo/up2.html
+++ b/funil_completo/up2.html
@@ -10,6 +10,7 @@
     <title>Oferta Especial</title>
     <link rel="stylesheet" href="../../cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="../../cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link rel="stylesheet" href="../public/css/payment-modal.css">
     <style>
         :root {
             --color-primary-start: #F58370;

--- a/funil_completo/up3.html
+++ b/funil_completo/up3.html
@@ -10,6 +10,7 @@
     <title>Oferta Especial</title>
     <link rel="stylesheet" href="../../cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="../../cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link rel="stylesheet" href="../public/css/payment-modal.css">
     <style>
         :root {
             --color-primary-start: #F58370;


### PR DESCRIPTION
## Summary
- load payment modal stylesheet on upsell pages so QR code and PIX key modal renders correctly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb473cdb94832aa992acc5e998b561