### PR TITLE
feat: add hideLoading for PIX modal

### DIFF
--- a/public/js/syncpay-integration.js
+++ b/public/js/syncpay-integration.js
@@ -796,11 +796,28 @@
             `;
             document.body.appendChild(loading);
         },
-        
+
+        hideLoading: function() {
+            if (typeof swal !== 'undefined' && typeof swal.close === 'function') {
+                try {
+                    swal.close();
+                } catch (error) {
+                    console.warn('Erro ao fechar SweetAlert:', error);
+                }
+            }
+
+            const existingLoading = document.getElementById('nativeLoading');
+            if (existingLoading) {
+                existingLoading.remove();
+            }
+        },
+
         showPixModal: function(data) {
             // Usar o modal de pagamento personalizado
             console.log('💳 PIX gerado:', data);
-            
+
+            this.hideLoading();
+
             try {
                 if (window.showPaymentModal && typeof window.showPaymentModal === 'function') {
                     // Usar o modal personalizado

--- a/public/js/universal-payment-integration.js
+++ b/public/js/universal-payment-integration.js
@@ -181,10 +181,27 @@
             document.body.appendChild(loading);
         }
 
+        hideLoading() {
+            if (typeof swal !== 'undefined' && typeof swal.close === 'function') {
+                try {
+                    swal.close();
+                } catch (error) {
+                    console.warn('Erro ao fechar SweetAlert:', error);
+                }
+            }
+
+            const existingLoading = document.getElementById('nativeLoading');
+            if (existingLoading) {
+                existingLoading.remove();
+            }
+        }
+
         showPixModal(data) {
             // Usar o modal de pagamento personalizado
             console.log(`💳 PIX gerado via ${data.gateway?.toUpperCase() || this.currentGateway.toUpperCase()}:`, data);
-            
+
+            this.hideLoading();
+
             try {
                 if (window.showPaymentModal && typeof window.showPaymentModal === 'function') {
                     // Usar o modal personalizado
@@ -231,6 +248,7 @@
     // Manter compatibilidade com código existente criando um bridge
     window.syncPay = {
         showLoading: () => universalPayment.showLoading(),
+        hideLoading: () => universalPayment.hideLoading(),
         createPixTransaction: (amount, description, clientData) => universalPayment.createPixTransaction(amount, description, clientData),
         showPixModal: (data) => universalPayment.showPixModal(data)
     };


### PR DESCRIPTION
## Summary
- add `hideLoading` helper to remove SweetAlert and native loader
- hide loader automatically when presenting PIX modal
- expose `hideLoading` in `window.syncPay` bridge

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb7ca8f80832a97aede0f8d9a2a63