### PR TITLE
Fix back routes and asset loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,7 @@
-<!DOCTYPE html><html class="v10" data-theme-lock="true"><head>
-   
+<!DOCTYPE html>
+<html class="v10" data-theme-lock="true">
+<head>
+    <base href="/">
     <script src="js/jquery.min.js" crossorigin="anonymous"></script>
     <!-- Required meta tags -->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/server.js
+++ b/server.js
@@ -706,6 +706,11 @@ app.get('/privacy', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
+// Alias para a página de checkout
+app.get('/checkout', (req, res) => {
+    res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
 app.get('/oferta-premiada', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'oferta-premiada', 'index.html'));
 });
@@ -732,11 +737,23 @@ app.get('/back1', (req, res) => {
     res.sendFile(path.join(__dirname, 'funil_completo', 'back1.html'));
 });
 
+app.get('/back1.html', (req, res) => {
+    res.sendFile(path.join(__dirname, 'funil_completo', 'back1.html'));
+});
+
 app.get('/back2', (req, res) => {
     res.sendFile(path.join(__dirname, 'funil_completo', 'back2.html'));
 });
 
+app.get('/back2.html', (req, res) => {
+    res.sendFile(path.join(__dirname, 'funil_completo', 'back2.html'));
+});
+
 app.get('/back3', (req, res) => {
+    res.sendFile(path.join(__dirname, 'funil_completo', 'back3.html'));
+});
+
+app.get('/back3.html', (req, res) => {
     res.sendFile(path.join(__dirname, 'funil_completo', 'back3.html'));
 });
 


### PR DESCRIPTION
## Summary
- add /checkout alias to serve main checkout page
- serve funil back pages when requested with .html suffix
- set base URL in checkout HTML for correct asset paths

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbd450b64832aa612f8499575cc53