### PR TITLE
Add global assets route and update upsell media paths

### DIFF
--- a/funil_completo/up2.html
+++ b/funil_completo/up2.html
@@ -775,7 +775,7 @@
     function loadMediaContent() {
         const currentPage = window.location.pathname.split('/').pop().replace('.html', '');
         const mediaContainer = document.getElementById('media-container');
-        const basePath = './assets/';
+        const basePath = '/assets/';
         
         // Tentar carregar vídeo primeiro
         const videoPath = basePath + currentPage + '.mp4';

--- a/funil_completo/up3.html
+++ b/funil_completo/up3.html
@@ -803,7 +803,7 @@
     function loadMediaContent() {
         const currentPage = window.location.pathname.split('/').pop().replace('.html', '');
         const mediaContainer = document.getElementById('media-container');
-        const basePath = './assets/';
+        const basePath = '/assets/';
         
         // Tentar carregar vídeo primeiro
         const videoPath = basePath + currentPage + '.mp4';

--- a/server.js
+++ b/server.js
@@ -780,6 +780,8 @@ app.use('/public', express.static(path.join(__dirname, 'public')));
 
 // Servir arquivos estáticos do funil completo
 app.use('/funil_completo', express.static(path.join(__dirname, 'funil_completo')));
+// Permitir acesso direto aos assets do funil
+app.use('/assets', express.static(path.join(__dirname, 'funil_completo/assets')));
 
 // Middleware para servir arquivos estáticos de forma mais flexível
 app.use('/images', express.static(path.join(__dirname, 'links/images')));

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,10 @@
       "dest": "/redirect-privacy/assets/$1"
     },
     {
+      "src": "/assets/(.*)",
+      "dest": "/funil_completo/assets/$1"
+    },
+    {
       "src": "/redirect-privacy",
       "dest": "/server.js"
     },


### PR DESCRIPTION
## Summary
- map `/assets` to `funil_completo/assets` on the server and Vercel config
- adjust upsell pages to load media from `/assets`

## Testing
- `npm test` (fails: no test specified)
- `curl -I http://localhost:3000/{up1,up2,up3,back1,back2,back3}`
- `curl -I http://localhost:3000/assets/{up1,up2,up3,back1,back2,back3}.mp4`


------
https://chatgpt.com/codex/tasks/task_e_68bbbf2a2484832aaf7c8d174593a901