### PR TITLE
Serve new images from public directory

### DIFF
--- a/server.js
+++ b/server.js
@@ -784,6 +784,7 @@ app.use('/funil_completo', express.static(path.join(__dirname, 'funil_completo')
 app.use('/assets', express.static(path.join(__dirname, 'funil_completo/assets')));
 
 // Middleware para servir arquivos estáticos de forma mais flexível
+app.use('/images', express.static(path.join(__dirname, 'public/images')));
 app.use('/images', express.static(path.join(__dirname, 'links/images')));
 app.use('/icons', express.static(path.join(__dirname, 'links/icons')));
 app.use('/compra-aprovada/images', express.static(path.join(__dirname, 'compra-aprovada/images')));


### PR DESCRIPTION
## Summary
- Serve new public images before legacy links images so new media works on up/back pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcb95dc5c832aa40135b3886ed546