### PR TITLE
Ensure proper redirects for Pix payment flow

### DIFF
--- a/funil_completo/assinatura-premiada.html
+++ b/funil_completo/assinatura-premiada.html
@@ -433,8 +433,8 @@
 
     <!-- CTAs (href vazio p/ sua API de PIX) -->
     <div class="cta-section fade-in">
-      <a href="#" class="btn btn-primary" onclick="gerarPixPlano('assinatura_premiada', 'Vídeo Personalizado - Assinatura Premiada', 17.00, 'obrigado.html');">GARANTIR MEU VÍDEO PERSONALIZADO</a>
-      <a href="obrigado.html" class="btn btn-secondary">Não, sou frouxo</a>
+      <a href="#" class="btn btn-primary" onclick="gerarPixPlano('assinatura_premiada', 'Vídeo Personalizado - Assinatura Premiada', 17.00, '/obrigado');">GARANTIR MEU VÍDEO PERSONALIZADO</a>
+      <a href="/obrigado" class="btn btn-secondary">Não, sou frouxo</a>
     </div>
 
     <!-- Footer -->
@@ -497,6 +497,9 @@
 
             // Usar a integração universal que detecta o gateway automaticamente
             const paymentService = window.universalPayment || window.syncPay;
+
+            // Definir plano atual para redirecionamento
+            window.currentPaymentPlan = planoId;
 
             // Mostrar loading
             if (paymentService.showLoading) {

--- a/public/js/payment-modal.js
+++ b/public/js/payment-modal.js
@@ -393,14 +393,17 @@ class PaymentModal {
         // Mapear planos para URLs de redirecionamento sequencial
         const planRedirects = {
             // Planos principais (primeira compra)
-            'monthly': '/funil_completo/up1.html',
-            'quarterly': '/funil_completo/up1.html', 
-            'semestrial': '/funil_completo/up1.html',
-            
+            'monthly': '/assinatura-premiada',
+            'quarterly': '/assinatura-premiada',
+            'semestrial': '/assinatura-premiada',
+
             // Upsells sequenciais
             'upsell1_videos': '/funil_completo/up2.html',
             'upsell2_chat': '/funil_completo/up3.html',
-            'upsell3_whatsapp': '/compra-aprovada/index.html'
+            'upsell3_whatsapp': '/compra-aprovada/index.html',
+
+            // Assinatura premiada
+            'assinatura_premiada': '/obrigado'
         };
 
         // Tentar detectar o plano atual baseado na transação

--- a/server.js
+++ b/server.js
@@ -722,6 +722,11 @@ app.get('/assinatura-premiada', (req, res) => {
     res.sendFile(path.join(__dirname, 'funil_completo', 'assinatura-premiada.html'));
 });
 
+// Página de agradecimento
+app.get('/obrigado', (req, res) => {
+    res.sendFile(path.join(__dirname, 'funil_completo', 'obrigado.html'));
+});
+
 // ============================
 // ROTAS DO FUNIL COMPLETO
 // ============================


### PR DESCRIPTION
## Summary
- Redirect initial Pix plans to `/assinatura-premiada`
- Add `/obrigado` thank-you route and update "Não, sou frouxo" button
- Track plan during purchase for correct redirect after Pix payment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c91ad260832ab1cb97998b577841