### PR TITLE
Fix decline redirect on assinatura-premiada upsell

### DIFF
--- a/funil_completo/assinatura-premiada.html
+++ b/funil_completo/assinatura-premiada.html
@@ -433,8 +433,8 @@
 
     <!-- CTAs (href vazio p/ sua API de PIX) -->
     <div class="cta-section fade-in">
-      <a href="#" class="btn btn-primary" onclick="gerarPixPlano('assinatura_premiada', 'Vídeo Personalizado - Assinatura Premiada', 17.00, '/assinatura-premiada');">GARANTIR MEU VÍDEO PERSONALIZADO</a>
-      <a href="/assinatura-premiada" class="btn btn-secondary">Não, sou frouxo</a>
+      <a href="#" class="btn btn-primary" onclick="gerarPixPlano('assinatura_premiada', 'Vídeo Personalizado - Assinatura Premiada', 17.00, '../compra-aprovada/index.html');">GARANTIR MEU VÍDEO PERSONALIZADO</a>
+      <a href="../compra-aprovada/index.html" class="btn btn-secondary">Não, sou frouxo</a>
     </div>
 
     <!-- Footer -->


### PR DESCRIPTION
## Summary
- Fix link for "Não, sou frouxo" to point to compra-aprovada page
- Ensure gerarPixPlano redirect after payment goes to compra-aprovada

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d49bbd20832a85ea937ae15cdd57